### PR TITLE
Wip mon perms as root

### DIFF
--- a/_modules/sesceph/mon.py
+++ b/_modules/sesceph/mon.py
@@ -363,6 +363,10 @@ class mon_implementation_base(object):
                     output["stdout"],
                     output["stderr"]
                     ))
+            # check keyring created:
+            path_mon_key = os.path.join(path_mon_dir, "keyring")
+            if not os.path.isfile(path_mon_key):
+                raise Error("Failed to create '%s'" % (path_mon_key))
             # Now start the service
             arguments = {
                 'identifier' : self.model.hostname,

--- a/_modules/sesceph/mon.py
+++ b/_modules/sesceph/mon.py
@@ -314,7 +314,7 @@ class mon_implementation_base(object):
                 "--import-keyring",
                 keyring_path_mon,
                 ]
-            output = self._execute(arguments)
+            output = utils.execute_local_command(arguments)
             if output["retcode"] != 0:
                 raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (
                     " ".join(arguments),
@@ -328,7 +328,7 @@ class mon_implementation_base(object):
                 "--import-keyring",
                 path_admin_keyring,
                 ]
-            output = self._execute(arguments)
+            output = utils.execute_local_command(arguments)
             if output["retcode"] != 0:
                 raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (
                     " ".join(arguments),
@@ -336,6 +336,8 @@ class mon_implementation_base(object):
                     output["stdout"],
                     output["stderr"]
                     ))
+            # Now chown the new file
+            os.chown(key_path, self.uid, self.gid)
             # Now clean the install area
             if os.path.isdir(path_mon_dir):
                 log.info("Remove directory content %s" %(path_mon_dir))


### PR DESCRIPTION
I will soon be doing a large rewrite of the keyring handling. Tightening up the perms on the keyrings.

When this happens the mon will fail to initialise. 

This will be due to the keyring not being present.  This is the first commit in this PR.
The reason the keyring is not present will be that the bootstrap keyring is not readable as user ceph. This is resolved with the second commit.
