### PR TITLE
Keyring refactor

### DIFF
--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -897,9 +897,9 @@ def keyring_rgw_auth_del(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "rgw"
-    return keyobj.auth_del(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "rgw"
+    return keyring_auth_del(**params)
 
 
 def keyring_rgw_purge(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -17,7 +17,6 @@ import mdl_updater
 import presenter
 import mdl_query
 import utils
-import keyring
 import osd
 import mon
 import rgw

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -636,9 +636,9 @@ def keyring_osd_auth_add(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "osd"
-    return keyobj.auth_add(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "osd"
+    return keyring_auth_add(**params)
 
 
 def keyring_osd_auth_del(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -658,9 +658,9 @@ def keyring_osd_auth_del(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "osd"
-    return keyobj.auth_del(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "osd"
+    return keyring_auth_del(**params)
 
 
 def keyring_osd_purge(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -340,6 +340,32 @@ def keyring_purge(**kwargs):
     return keyring_use.keyring_purge_type(**kwargs)
 
 
+def keyring_auth_add(**kwargs):
+    """
+    Add keyring to authorised list
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_mon_present \\
+                'keyring_type'='admin' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    keyring_type
+        Required paramter
+        Can be set to:
+            admin, mon, osd, rgw, mds
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    """
+    return keyring_use.keyring_auth_add_type(**kwargs)
+
+
 def keyring_admin_create(**kwargs):
     """
     Create admin keyring for cluster

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -799,9 +799,9 @@ def keyring_mds_purge(**kwargs):
 
     If no ceph config file is found, this command will fail.
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mds"
-    return keyobj.remove(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mds"
+    return keyring_purge(**params)
 
 
 def keyring_rgw_create(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -1083,7 +1083,8 @@ def purge(**kwargs):
 
         salt '*' sesceph.purge
     """
-    purger.purge(**kwargs)
+    m = model.model(**kwargs)
+    purger.purge(m, **kwargs)
 
 
 def ceph_version():

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -458,14 +458,13 @@ def keyring_admin_save(key_content=None, **kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    if (key_content is None) != ('secret' in kwargs):
-        raise Error("Set either the key_content or the key `secret`")
-    if 'secret' in kwargs:
-        utils.is_valid_base64(kwargs['secret'])
-
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "admin"
-    return keyobj.write(key_content, **kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "admin"
+    if key_content is None:
+        return keyring_save(**params)
+    log.warning("keyring_admin_save using legacy argument call")
+    params["key_content"] = str(key_content)
+    return keyring_save(**params)
 
 
 def keyring_admin_purge(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -607,7 +607,7 @@ def keyring_osd_save(key_content=None, **kwargs):
         Set the cluster name. Defaults to "ceph".
     """
     params = dict(kwargs)
-    params["keyring_type"] = "mon"
+    params["keyring_type"] = "osd"
     if key_content is None:
         return keyring_save(**params)
     log.warning("keyring_admin_save using legacy argument call")

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -875,9 +875,9 @@ def keyring_rgw_auth_add(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "rgw"
-    return keyobj.auth_add(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "rgw"
+    return keyring_auth_add(**params)
 
 
 def keyring_rgw_auth_del(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -24,6 +24,7 @@ import rgw
 import mds
 import purger
 import mdl_updater_remote
+import keyring_use
 
 log = logging.getLogger(__name__)
 
@@ -256,6 +257,31 @@ def osd_activate(**kwargs):
     """
     return osd.osd_activate(**kwargs)
 
+
+def keyring_create(**kwargs):
+    """
+    Create keyring for cluster
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_create \\
+                'keyring_type'='admin' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    keyring_type
+        Required paramter
+        Can be set to:
+            admin, mon, osd, rgw, mds
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    """
+    return keyring_use.keyring_create_type(**kwargs)
 
 
 def keyring_admin_create(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -726,14 +726,14 @@ def keyring_mds_save(key_content=None, **kwargs):
 
     If the value is set, it will not be changed untill the keyring is deleted.
     """
-    if (key_content is None) != ('secret' in kwargs):
-        raise Error("Set either the key_content or the key `secret`")
-    if 'secret' in kwargs:
-        utils.is_valid_base64(kwargs['secret'])
+    params = dict(kwargs)
+    params["keyring_type"] = "mds"
+    if key_content is None:
+        return keyring_save(**params)
+    log.warning("keyring_admin_save using legacy argument call")
+    params["key_content"] = str(key_content)
+    return keyring_save(**params)
 
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mds"
-    return keyobj.write(key_content, **kwargs)
 
 def keyring_mds_auth_add(**kwargs):
     """

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -532,14 +532,13 @@ def keyring_mon_save(key_content=None, **kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    if (key_content is None) != ('secret' in kwargs):
-        raise Error("Set either the key_content or the key `secret`")
-    if 'secret' in kwargs:
-        utils.is_valid_base64(kwargs['secret'])
-
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mon"
-    return keyobj.write(key_content, **kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mon"
+    if key_content is None:
+        return keyring_save(**params)
+    log.warning("keyring_admin_save using legacy argument call")
+    params["key_content"] = str(key_content)
+    return keyring_save(**params)
 
 
 def keyring_mon_purge(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -755,9 +755,9 @@ def keyring_mds_auth_add(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mds"
-    return keyobj.auth_add(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mds"
+    return keyring_auth_add(**params)
 
 
 def keyring_mds_auth_del(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -435,9 +435,9 @@ def keyring_admin_create(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "admin"
-    return keyobj.create(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "admin"
+    return keyring_create(**params)
 
 
 def keyring_admin_save(key_content=None, **kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -366,6 +366,32 @@ def keyring_auth_add(**kwargs):
     return keyring_use.keyring_auth_add_type(**kwargs)
 
 
+def keyring_auth_del(**kwargs):
+    """
+    Remove keyring from authorised list
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_osd_auth_del \\
+                'keyring_type'='admin' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    keyring_type
+        Required paramter
+        Can be set to:
+            admin, mon, osd, rgw, mds
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    """
+    return keyring_use.keyring_auth_add_type(key_content, **kwargs)
+
+
 def keyring_admin_create(**kwargs):
     """
     Create admin keyring for cluster

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -606,14 +606,13 @@ def keyring_osd_save(key_content=None, **kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    if (key_content is None) != ('secret' in kwargs):
-        raise Error("Set either the key_content or the key `secret`")
-    if 'secret' in kwargs:
-        utils.is_valid_base64(kwargs['secret'])
-
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "osd"
-    return keyobj.write(key_content, **kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mon"
+    if key_content is None:
+        return keyring_save(**params)
+    log.warning("keyring_admin_save using legacy argument call")
+    params["key_content"] = str(key_content)
+    return keyring_save(**params)
 
 
 def keyring_osd_auth_add(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -311,6 +311,35 @@ def keyring_save(**kwargs):
     return keyring_use.keyring_save_type(**kwargs)
 
 
+def keyring_purge(**kwargs):
+    """
+    Delete keyring for cluster
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_purge \\
+                'keyring_type'='admin' \\
+                '[mds.]\n\tkey = AQA/vZ9WyDwsKRAAxQ6wjGJH6WV8fDJeyzxHrg==\n\tcaps mds = \"allow *\"\n' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    keyring_type
+        Required paramter
+        Can be set to:
+            admin, mon, osd, rgw, mds
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+
+    If no ceph config file is found, this command will fail.
+    """
+    return keyring_use.keyring_purge_type(**kwargs)
+
+
 def keyring_admin_create(**kwargs):
     """
     Create admin keyring for cluster

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -847,13 +847,14 @@ def keyring_rgw_save(key_content=None, **kwargs):
 
     If the value is set, it will not be changed untill the keyring is deleted.
     """
-    if (key_content is None) != ('secret' in kwargs):
-        raise Error("Set either the key_content or the key `secret`")
-    if 'secret' in kwargs:
-        utils.is_valid_base64(kwargs['secret'])
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "rgw"
-    return keyobj.write(key_content, **kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "rgw"
+    if key_content is None:
+        return keyring_save(**params)
+    log.warning("keyring_admin_save using legacy argument call")
+    params["key_content"] = str(key_content)
+    return keyring_save(**params)
+
 
 def keyring_rgw_auth_add(**kwargs):
     """

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -678,10 +678,9 @@ def keyring_osd_purge(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "osd"
-    return keyobj.remove(**kwargs)
-
+    params = dict(kwargs)
+    params["keyring_type"] = "osd"
+    return keyring_purge(**params)
 
 
 def keyring_mds_create(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -561,9 +561,9 @@ def keyring_mon_purge(**kwargs):
 
     If no ceph config file is found, this command will fail.
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mon"
-    return keyobj.remove(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mon"
+    return keyring_purge(**params)
 
 
 def keyring_osd_create(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -487,9 +487,9 @@ def keyring_admin_purge(**kwargs):
 
     If no ceph config file is found, this command will fail.
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "admin"
-    return keyobj.remove(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "admin"
+    return keyring_purge(**params)
 
 
 def keyring_mon_create(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -510,9 +510,9 @@ def keyring_mon_create(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mon"
-    return keyobj.create(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mon"
+    return keyring_create(**params)
 
 
 def keyring_mon_save(key_content=None, **kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -284,6 +284,33 @@ def keyring_create(**kwargs):
     return keyring_use.keyring_create_type(**kwargs)
 
 
+def keyring_save(**kwargs):
+    """
+    Create save keyring locally
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_save \\
+                'keyring_type'='admin' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid' \\
+                ''
+    Notes:
+
+    keyring_type
+        Required paramter
+        Can be set to:
+            admin, mon, osd, rgw, mds
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    """
+    return keyring_use.keyring_save_type(**kwargs)
+
+
 def keyring_admin_create(**kwargs):
     """
     Create admin keyring for cluster

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -585,9 +585,9 @@ def keyring_osd_create(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "osd"
-    return keyobj.create(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "osd"
+    return keyring_create(**params)
 
 
 def keyring_osd_save(key_content=None, **kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -777,9 +777,9 @@ def keyring_mds_auth_del(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mds"
-    return keyobj.auth_del(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mds"
+    return keyring_auth_del(**params)
 
 
 def keyring_mds_purge(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -341,7 +341,7 @@ def keyring_purge(**kwargs):
 
 def keyring_present(**kwargs):
     """
-    Is mon keyring on disk
+    Is keyring on disk
 
     CLI Example:
 

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -340,6 +340,32 @@ def keyring_purge(**kwargs):
     return keyring_use.keyring_purge_type(**kwargs)
 
 
+def keyring_present(**kwargs):
+    """
+    Is mon keyring on disk
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_mon_present \\
+                'keyring_type'='admin' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    keyring_type
+    Required paramter
+    Can be set to:
+        admin, mon, osd, rgw, mds
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    """
+    return keyring_use.keyring_present_type(**kwargs)
+
+
 def keyring_auth_add(**kwargs):
     """
     Add keyring to authorised list

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -415,7 +415,7 @@ def keyring_auth_del(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    return keyring_use.keyring_auth_add_type(key_content, **kwargs)
+    return keyring_use.keyring_auth_add_type(**kwargs)
 
 
 def keyring_admin_create(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -825,9 +825,9 @@ def keyring_rgw_create(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "rgw"
-    return keyobj.create(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "rgw"
+    return keyring_create(**params)
 
 
 def keyring_rgw_save(key_content=None, **kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -920,10 +920,9 @@ def keyring_rgw_purge(**kwargs):
 
     If no ceph config file is found, this command will fail.
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "rgw"
-    return keyobj.remove(**kwargs)
-
+    params = dict(kwargs)
+    params["keyring_type"] = "rgw"
+    return keyring_purge(**params)
 
 
 def mon_is(**kwargs):

--- a/_modules/sesceph/__init__.py
+++ b/_modules/sesceph/__init__.py
@@ -704,9 +704,10 @@ def keyring_mds_create(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     """
-    keyobj = keyring.keyring_facard()
-    keyobj.key_type = "mds"
-    return keyobj.create(**kwargs)
+    params = dict(kwargs)
+    params["keyring_type"] = "mds"
+    return keyring_create(**params)
+
 
 def keyring_mds_save(key_content=None, **kwargs):
     """

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -139,18 +139,13 @@ class keyring_implementation_base(object):
         return output
 
 
-    def write(self, **kwargs):
+    def write_content(self, key_content):
         """
         Persist keyring
         """
         keyring_path = self.get_path_keyring()
         if os.path.isfile(keyring_path):
             return True
-        key_content = kwargs.get('key_content')
-        # We only check for secret, as init itself catches the case if
-        # key_content is already set
-        if 'secret' in kwargs:
-            key_content=self.create(**kwargs)
         _keying_write(keyring_path, key_content)
         return True
 
@@ -333,13 +328,13 @@ class keyring_facard(object):
         return self._keyImp.create(secret)
 
 
-    def write(self, **kwargs):
+    def write_content(self, key_content):
         """
         Persist keyring
         """
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
-        return self._keyImp.write(**kwargs)
+        return self._keyImp.write_content(key_content)
 
 
     def remove(self, **kwargs):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -104,7 +104,7 @@ class keyring_implementation_base(object):
         return args
 
 
-    def present(self, **kwargs):
+    def present(self):
         """
         Is keyring present
         """
@@ -317,13 +317,13 @@ class keyring_facard(object):
         return locals()
 
 
-    def present(self, **kwargs):
+    def present(self):
         """
         Create keyring
         """
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
-        return self._keyImp.present(**kwargs)
+        return self._keyImp.present()
 
 
     def create(self, **kwargs):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -386,6 +386,7 @@ class keyring_facard(object):
             raise Error("Programming error: key type unset")
         return self._keyImp.auth_add(**kwargs)
 
+
     def auth_del(self, **kwargs):
         """
         Authorise keyring
@@ -393,6 +394,7 @@ class keyring_facard(object):
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
         return self._keyImp.auth_del(**kwargs)
+
 
     def remove(self, **kwargs):
         """

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -286,7 +286,7 @@ class keyring_facard(object):
                 self._clear_implementation()
             if not name in self._availableKeys:
                 self._clear_implementation()
-                raise Error("Invalid Value")
+                raise Error("Invalid Value:%s" % (name))
             implementation = None
             if name == "admin":
                 implementation = keyring_implementation_admin(self.model)
@@ -300,7 +300,7 @@ class keyring_facard(object):
                 implementation = keyring_implementation_rgw(self.model)
             if implementation is None:
                 self._clear_implementation()
-                raise Error("Invalid Value")
+                raise Error("Programming error for invalid Value:%s" % (name))
             try:
                 implementation.get_path_keyring()
             except Error, e:

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -141,19 +141,18 @@ class keyring_implementation_base(object):
 
 
 
-    def write(self, key_content=None, **kwargs):
+    def write(self, **kwargs):
         """
         Persist keyring
         """
         keyring_path = self.get_path_keyring()
         if os.path.isfile(keyring_path):
             return True
-
+        key_content = kwargs.get('key_content')
         # We only check for secret, as init itself catches the case if
         # key_content is already set
         if 'secret' in kwargs:
             key_content=self.create(**kwargs)
-
         _keying_write(keyring_path, key_content)
         return True
 
@@ -336,13 +335,13 @@ class keyring_facard(object):
         return self._keyImp.create(**kwargs)
 
 
-    def write(self, key_content=None, **kwargs):
+    def write(self, **kwargs):
         """
         Persist keyring
         """
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
-        return self._keyImp.write(key_content,**kwargs)
+        return self._keyImp.write(**kwargs)
 
 
     def remove(self, **kwargs):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -73,7 +73,7 @@ def Property(func):
 
 
 class keyring_implementation_base(object):
-    def __init__(self, mdl, **kwargs):
+    def __init__(self, mdl):
         self.model = mdl
 
 

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -150,6 +150,28 @@ class keyring_implementation_base(object):
         return True
 
 
+    def write_secret(self, secret):
+        """
+        Persist keyring
+        """
+        keyring_path = self.get_path_keyring()
+        if os.path.isfile(keyring_path):
+            return True
+        if secret is None:
+            raise Error("Keyring secret is invalid")
+        arguments = self.get_arguments_create(keyring_path, secret)
+        cmd_out = utils.execute_local_command(arguments)
+        if cmd_out["retcode"] != 0:
+            raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (
+                " ".join(arguments),
+                cmd_out["retcode"],
+                cmd_out["stdout"],
+                cmd_out["stderr"])
+                )
+        output = _keying_read(keyring_path)
+        return True
+
+
     def remove(self, **kwargs):
         """
         Delete keyring
@@ -335,6 +357,15 @@ class keyring_facard(object):
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
         return self._keyImp.write_content(key_content)
+
+
+    def write_secret(self, secret):
+        """
+        Persist keyring
+        """
+        if self._keyImp is None:
+            raise Error("Programming error: key type unset")
+        return self._keyImp.write_secret(secret)
 
 
     def remove(self, **kwargs):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -208,7 +208,7 @@ class keyring_implementation_mon(keyring_implementation_base):
         if self.model.cluster_name is None:
             raise  Error("Cluster name not found")
         if self.model.hostname is None:
-            raise  Error("Cluster name not found")
+            raise  Error("hostname not found")
         return _get_path_keyring_mon_bootstrap(self.model.cluster_name,
                 self.model.hostname)
 

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -117,7 +117,8 @@ class keyring_implementation_base(object):
         try:
             tmpd = tempfile.mkdtemp()
             key_path = os.path.join(tmpd,"keyring")
-            cmd_out = utils.execute_local_command(self.get_arguments_create(key_path,self.model.secret))
+            secret = kwargs.get("secret", None)
+            cmd_out = utils.execute_local_command(self.get_arguments_create(key_path, secret))
             output = _keying_read(key_path)
         finally:
             shutil.rmtree(tmpd)

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -125,7 +125,15 @@ class keyring_implementation_base(object):
             tmpd = tempfile.mkdtemp()
             key_path = os.path.join(tmpd,"keyring")
             secret = kwargs.get("secret", None)
-            cmd_out = utils.execute_local_command(self.get_arguments_create(key_path, secret))
+            arguments = self.get_arguments_create(key_path, secret)
+            cmd_out = utils.execute_local_command(arguments)
+            if cmd_out["retcode"] != 0:
+                raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (
+                    " ".join(arguments),
+                    cmd_out["retcode"],
+                    cmd_out["stdout"],
+                    cmd_out["stderr"])
+                    )
             output = _keying_read(key_path)
         finally:
             shutil.rmtree(tmpd)

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -93,7 +93,7 @@ class keyring_implementation_base(object):
         args=[constants._path_ceph_authtool, "-n", keyring_name, "--create-keyring", keyring_path]
 
         if secret:
-            args += ["--add-key", secret]
+            args += ["--add-key", secret.strip()]
         else:
             args.append("--gen-key")
 

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -114,7 +114,7 @@ class keyring_implementation_base(object):
         return False
 
 
-    def create(self, **kwargs):
+    def create(self, secret = None):
         """
         Create keyring
         """
@@ -124,7 +124,6 @@ class keyring_implementation_base(object):
         try:
             tmpd = tempfile.mkdtemp()
             key_path = os.path.join(tmpd,"keyring")
-            secret = kwargs.get("secret", None)
             arguments = self.get_arguments_create(key_path, secret)
             cmd_out = utils.execute_local_command(arguments)
             if cmd_out["retcode"] != 0:
@@ -138,7 +137,6 @@ class keyring_implementation_base(object):
         finally:
             shutil.rmtree(tmpd)
         return output
-
 
 
     def write(self, **kwargs):
@@ -326,13 +324,13 @@ class keyring_facard(object):
         return self._keyImp.present()
 
 
-    def create(self, **kwargs):
+    def create(self, secret = None):
         """
         Create keyring
         """
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
-        return self._keyImp.create(**kwargs)
+        return self._keyImp.create(secret)
 
 
     def write(self, **kwargs):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -300,7 +300,7 @@ class keyring_facard(object):
                 self._clear_implementation()
             if not name in self._availableKeys:
                 self._clear_implementation()
-                raise Error("Invalid Value:%s" % (name))
+                raise ValueError("Invalid key_type with value:%s" % (name))
             implementation = None
             if name == "admin":
                 implementation = keyring_implementation_admin(self.model)
@@ -314,7 +314,7 @@ class keyring_facard(object):
                 implementation = keyring_implementation_rgw(self.model)
             if implementation is None:
                 self._clear_implementation()
-                raise Error("Programming error for invalid Value:%s" % (name))
+                raise ValueError("Programming error for key_type with value:%s" % (name))
             try:
                 implementation.get_path_keyring()
             except Error, e:

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -172,7 +172,7 @@ class keyring_implementation_base(object):
         return True
 
 
-    def remove(self, **kwargs):
+    def remove(self):
         """
         Delete keyring
         """
@@ -368,13 +368,13 @@ class keyring_facard(object):
         return self._keyImp.write_secret(secret)
 
 
-    def remove(self, **kwargs):
+    def remove(self):
         """
         Remove keyring
         """
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
-        return self._keyImp.remove(**kwargs)
+        return self._keyImp.remove()
 
 
     def keyring_path_get(self):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -104,6 +104,16 @@ class keyring_implementation_base(object):
         return args
 
 
+    def present(self, **kwargs):
+        """
+        Is keyring present
+        """
+        keyring_path = self.get_path_keyring()
+        if os.path.isfile(keyring_path):
+            return True
+        return False
+
+
     def create(self, **kwargs):
         """
         Create keyring
@@ -339,6 +349,16 @@ class keyring_facard(object):
 
 
         return locals()
+
+
+    def present(self, **kwargs):
+        """
+        Create keyring
+        """
+        if self._keyImp is None:
+            raise Error("Programming error: key type unset")
+        return self._keyImp.present(**kwargs)
+
 
     def create(self, **kwargs):
         """

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -158,48 +158,6 @@ class keyring_implementation_base(object):
         return True
 
 
-    def auth_add(self, **kwargs):
-        """
-        Authorise keyring
-        """
-        keyring_path = self.get_path_keyring()
-        if not os.path.isfile(keyring_path):
-            raise Error("rgw keyring not found")
-        q = mdl_query.mdl_query(self.model)
-        if not q.mon_is():
-            raise Error("Not ruining a mon daemon")
-        if not q.mon_quorum():
-            raise Error("mon daemon is not in quorum")
-        arguments = [
-                "ceph",
-                "auth",
-                "import",
-                "-i",
-                keyring_path
-                ]
-        cmd_out = utils.execute_local_command(arguments)
-        return True
-
-
-    def auth_del(self, **kwargs):
-        """
-        Remove Authorised keyring
-        """
-        q = mdl_query.mdl_query(self.model)
-        if not q.mon_is():
-            raise Error("Not ruining a mon daemon")
-        if not q.mon_quorum():
-            raise Error("mon daemon is not in quorum")
-        arguments = [
-                "ceph",
-                "auth",
-                "del",
-                self.keyring_name
-                ]
-        cmd_out = utils.execute_local_command(arguments)
-        return True
-
-
     def remove(self, **kwargs):
         """
         Delete keyring
@@ -385,24 +343,6 @@ class keyring_facard(object):
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
         return self._keyImp.write(key_content,**kwargs)
-
-
-    def auth_add(self, **kwargs):
-        """
-        Authorise keyring
-        """
-        if self._keyImp is None:
-            raise Error("Programming error: key type unset")
-        return self._keyImp.auth_add(**kwargs)
-
-
-    def auth_del(self, **kwargs):
-        """
-        Authorise keyring
-        """
-        if self._keyImp is None:
-            raise Error("Programming error: key type unset")
-        return self._keyImp.auth_del(**kwargs)
 
 
     def remove(self, **kwargs):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -344,7 +344,6 @@ class keyring_facard(object):
         """
         Create keyring
         """
-        self.key_type == 'osd'
         if self._keyImp is None:
             raise Error("Programming error: key type unset")
         return self._keyImp.create(**kwargs)

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -207,6 +207,7 @@ class keyring_implementation_base(object):
         keyring_path = self.get_path_keyring()
         if os.path.isfile(keyring_path):
             try:
+                log.info("Removing" , keyring_path)
                 os.remove(keyring_path)
             except:
                 raise Error("Keyring could not be deleted")

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -171,6 +171,8 @@ def keyring_auth_del_type(**kwargs):
     u.mon_status()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
+    if not keyobj.present():
+        raise Error("keyring not present")
     return keyobj.auth_del(**kwargs)
 
 

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -7,6 +7,7 @@ import mdl_updater
 import keyring
 import utils
 import mdl_query
+import mdl_updater_remote
 
 
 log = logging.getLogger(__name__)
@@ -127,7 +128,12 @@ def keyring_auth_add_type(key_content=None, **kwargs):
     keyobj.key_type = keyring_type
     if not keyobj.present():
         raise Error("keyring not present")
-    return keyobj.auth_add(**kwargs)
+    mur = mdl_updater_remote.model_updater_remote(m)
+    can_connect = mur.connect()
+    if not can_connect:
+        raise Error("Cant connect to cluster.")
+    mur.auth_add(keyring_type)
+    return mur.auth_add(keyring_type)
 
 
 

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -125,6 +125,8 @@ def keyring_auth_add_type(key_content=None, **kwargs):
     u.mon_status()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
+    if not keyobj.present():
+        raise Error("keyring not present")
     return keyobj.auth_add(**kwargs)
 
 

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -108,7 +108,7 @@ def keyring_save_type(**kwargs):
     return keyobj.write(key_content, **kwargs)
 
 
-def keyring_auth_add_type(key_content=None, **kwargs):
+def keyring_auth_add_type(**kwargs):
     keyring_type = kwargs.get("keyring_type")
     if (keyring_type is None):
         raise Error("keyring_type is None")
@@ -121,9 +121,8 @@ def keyring_auth_add_type(key_content=None, **kwargs):
     u.load_confg(m.cluster_name)
     u.mon_members_refresh()
     q = mdl_query.mdl_query(m)
-    if not q.mon_is():
-        raise Error("Not ruining a mon daemon")
-    u.mon_status()
+    if q.mon_is():
+        u.mon_status()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
     if not keyobj.present():
@@ -132,7 +131,6 @@ def keyring_auth_add_type(key_content=None, **kwargs):
     can_connect = mur.connect()
     if not can_connect:
         raise Error("Cant connect to cluster.")
-    mur.auth_add(keyring_type)
     return mur.auth_add(keyring_type)
 
 
@@ -166,9 +164,8 @@ def keyring_auth_del_type(**kwargs):
     u.load_confg(m.cluster_name)
     u.mon_members_refresh()
     q = mdl_query.mdl_query(m)
-    if not q.mon_is():
-        raise Error("Not ruining a mon daemon")
-    u.mon_status()
+    if q.mon_is():
+        u.mon_status()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
     if not keyobj.present():
@@ -177,7 +174,6 @@ def keyring_auth_del_type(**kwargs):
     can_connect = mur.connect()
     if not can_connect:
         raise Error("Cant connect to cluster.")
-    mur.auth_add(keyring_type)
     return mur.auth_del(keyring_type)
 
 

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -1,0 +1,167 @@
+# Python imports
+import logging
+
+# local modules
+import model
+import mdl_updater
+import keyring
+import utils
+import mdl_query
+
+
+log = logging.getLogger(__name__)
+
+
+class Error(Exception):
+    """
+    Error
+    """
+
+    def __str__(self):
+        doc = self.__doc__.strip()
+        return ': '.join([doc] + [str(a) for a in self.args])
+
+def keyring_create_type(**kwargs):
+    keyring_type = kwargs.get("keyring_type")
+    if (keyring_type is None):
+        raise Error("keyring_type is None")
+    m = model.model(**kwargs)
+    u = mdl_updater.model_updater(m)
+    u.hostname_refresh()
+    u.defaults_refresh()
+    u.load_confg(m.cluster_name)
+    u.mon_members_refresh()
+    keyobj = keyring.keyring_facard(m)
+    keyobj.key_type = keyring_type
+    return keyobj.create(**kwargs)
+
+
+def keyring_present_type(**kwargs):
+    """
+    Check if keyring exists on disk
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_admin_save \\
+                '[mon.]\n\tkey = AQA/vZ9WyDwsKRAAxQ6wjGJH6WV8fDJeyzxHrg==\n\tcaps mon = \"allow *\"\n' \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    keyring_type
+        Set the keyring type
+    """
+    keyring_type = kwargs.get("keyring_type")
+    if (keyring_type is None):
+        raise Error("keyring_type is None")
+    m = model.model(**kwargs)
+    u = mdl_updater.model_updater(m)
+    u.hostname_refresh()
+    try:
+        u.defaults_refresh()
+    except:
+        pass
+    keyobj = keyring.keyring_facard(m)
+    keyobj.key_type = keyring_type
+    return keyobj.present(**kwargs)
+
+
+
+def _keyring_purge_type(keyring_type, **kwargs):
+    m = model.model(**kwargs)
+    u = mdl_updater.model_updater(m)
+    u.hostname_refresh()
+    u.defaults_refresh()
+    u.load_confg(m.cluster_name)
+    u.mon_members_refresh()
+    keyobj = keyring.keyring_facard(m)
+    keyobj.key_type = keyring_type
+    return keyobj.remove(**kwargs)
+
+
+def keyring_save_type(key_content=None, **kwargs):
+    keyring_type = kwargs.get("keyring_type")
+    if (keyring_type is None):
+        raise Error("keyring_type is None")
+    key_content = kwargs.get("key_content")
+    
+    secret = kwargs.get("secret")
+    
+    if (key_content is None) and (secret is None):
+        raise Error("Set either the key_content or the key `secret`")
+    if 'secret' in kwargs:
+        utils.is_valid_base64(kwargs['secret'])
+    
+    m = model.model(**kwargs)
+    u = mdl_updater.model_updater(m)
+    u.hostname_refresh()
+    u.defaults_refresh()
+    u.load_confg(m.cluster_name)
+    u.mon_members_refresh()
+    keyobj = keyring.keyring_facard(m)
+    keyobj.key_type = keyring_type
+    return keyobj.write(key_content, **kwargs)
+
+
+def keyring_auth_add_type(key_content=None, **kwargs):
+    keyring_type = kwargs.get("keyring_type")
+    if (keyring_type is None):
+        raise Error("keyring_type is None")
+    if (keyring_type in set(["mon","admin"])):
+        raise Error("keyring_type is %s" % (keyring_type))
+    m = model.model(**kwargs)
+    u = mdl_updater.model_updater(m)
+    u.hostname_refresh()
+    u.defaults_refresh()
+    u.load_confg(m.cluster_name)
+    u.mon_members_refresh()
+    q = mdl_query.mdl_query(m)
+    if not q.mon_is():
+        raise Error("Not ruining a mon daemon")
+    u.mon_status()
+    keyobj = keyring.keyring_facard(m)
+    keyobj.key_type = keyring_type
+    return keyobj.auth_add(**kwargs)
+
+
+
+def keyring_auth_del_type(**kwargs):
+    """
+    Write rgw keyring for cluster
+
+    CLI Example:
+
+        salt '*' sesceph.keyring_mds_auth_del \\
+                'cluster_name'='ceph' \\
+                'cluster_uuid'='cluster_uuid'
+    Notes:
+
+    cluster_uuid
+        Set the cluster UUID. Defaults to value found in ceph config file.
+
+    cluster_name
+        Set the cluster name. Defaults to "ceph".
+    """
+    keyring_type = kwargs.get("keyring_type")
+    if (keyring_type is None):
+        raise Error("keyring_type is None")
+    if (keyring_type in set(["mon","admin"])):
+        raise Error("keyring_type is %s" % (keyring_type))
+    m = model.model(**kwargs)
+    u = mdl_updater.model_updater(m)
+    u.hostname_refresh()
+    u.defaults_refresh()
+    u.load_confg(m.cluster_name)
+    u.mon_members_refresh()
+    q = mdl_query.mdl_query(m)
+    if not q.mon_is():
+        raise Error("Not ruining a mon daemon")
+    u.mon_status()
+    keyobj = keyring.keyring_facard(m)
+    keyobj.key_type = keyring_type
+    return keyobj.auth_del(**kwargs)

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -72,6 +72,9 @@ def keyring_present_type(**kwargs):
 
 
 def _keyring_purge_type(keyring_type, **kwargs):
+    keyring_type = kwargs.get("keyring_type", None)
+    if (keyring_type is None):
+        raise Error("keyring_type is not set")
     m = model.model(**kwargs)
     u = mdl_updater.model_updater(m)
     u.hostname_refresh()
@@ -161,3 +164,6 @@ def keyring_auth_del_type(**kwargs):
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
     return keyobj.auth_del(**kwargs)
+
+
+

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -26,6 +26,7 @@ def keyring_create_type(**kwargs):
     keyring_type = kwargs.get("keyring_type")
     if (keyring_type is None):
         raise Error("keyring_type is None")
+    secret = kwargs.get("secret")
     m = model.model(**kwargs)
     u = mdl_updater.model_updater(m)
     u.hostname_refresh()
@@ -34,7 +35,7 @@ def keyring_create_type(**kwargs):
     u.mon_members_refresh()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
-    return keyobj.create(**kwargs)
+    return keyobj.create(secret=secret)
 
 
 def keyring_present_type(**kwargs):

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -107,7 +107,6 @@ def keyring_save_type(**kwargs):
         return keyobj.write_content(key_content)
     raise Error("Set either the key_content or the key `secret`")
 
-
 def keyring_auth_add_type(**kwargs):
     keyring_type = kwargs.get("keyring_type")
     if (keyring_type is None):

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -173,7 +173,12 @@ def keyring_auth_del_type(**kwargs):
     keyobj.key_type = keyring_type
     if not keyobj.present():
         raise Error("keyring not present")
-    return keyobj.auth_del(**kwargs)
+    mur = mdl_updater_remote.model_updater_remote(m)
+    can_connect = mur.connect()
+    if not can_connect:
+        raise Error("Cant connect to cluster.")
+    mur.auth_add(keyring_type)
+    return mur.auth_del(keyring_type)
 
 
 

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -86,7 +86,7 @@ def _keyring_purge_type(keyring_type, **kwargs):
     return keyobj.remove(**kwargs)
 
 
-def keyring_save_type(key_content=None, **kwargs):
+def keyring_save_type(**kwargs):
     keyring_type = kwargs.get("keyring_type")
     if (keyring_type is None):
         raise Error("keyring_type is None")

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -70,7 +70,7 @@ def keyring_present_type(**kwargs):
         pass
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
-    return keyobj.present(**kwargs)
+    return keyobj.present()
 
 
 def keyring_purge_type(**kwargs):

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -90,14 +90,8 @@ def keyring_purge_type(**kwargs):
 
 def keyring_save_type(**kwargs):
     keyring_type = kwargs.get("keyring_type")
-    if (keyring_type is None):
-        raise Error("keyring_type is None")
     key_content = kwargs.get("key_content")
     secret = kwargs.get("secret")
-    if (key_content is None) and (secret is None):
-        raise Error("Set either the key_content or the key `secret`")
-    if 'secret' in kwargs:
-        utils.is_valid_base64(kwargs['secret'])
     m = model.model(**kwargs)
     u = mdl_updater.model_updater(m)
     u.hostname_refresh()
@@ -106,7 +100,12 @@ def keyring_save_type(**kwargs):
     u.mon_members_refresh()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
-    return keyobj.write(key_content, **kwargs)
+    if secret is not None:
+        utils.is_valid_base64(secret)
+        return keyobj.write_secret(secret)
+    if key_content is not None:
+        return keyobj.write_content(key_content)
+    raise Error("Set either the key_content or the key `secret`")
 
 
 def keyring_auth_add_type(**kwargs):

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -71,7 +71,7 @@ def keyring_present_type(**kwargs):
     return keyobj.present(**kwargs)
 
 
-def _keyring_purge_type(keyring_type, **kwargs):
+def keyring_purge_type(**kwargs):
     keyring_type = kwargs.get("keyring_type", None)
     if (keyring_type is None):
         raise Error("keyring_type is not set")

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -85,7 +85,7 @@ def keyring_purge_type(**kwargs):
     u.mon_members_refresh()
     keyobj = keyring.keyring_facard(m)
     keyobj.key_type = keyring_type
-    return keyobj.remove(**kwargs)
+    return keyobj.remove()
 
 
 def keyring_save_type(**kwargs):

--- a/_modules/sesceph/keyring_use.py
+++ b/_modules/sesceph/keyring_use.py
@@ -71,7 +71,6 @@ def keyring_present_type(**kwargs):
     return keyobj.present(**kwargs)
 
 
-
 def _keyring_purge_type(keyring_type, **kwargs):
     m = model.model(**kwargs)
     u = mdl_updater.model_updater(m)
@@ -89,14 +88,11 @@ def keyring_save_type(key_content=None, **kwargs):
     if (keyring_type is None):
         raise Error("keyring_type is None")
     key_content = kwargs.get("key_content")
-    
     secret = kwargs.get("secret")
-    
     if (key_content is None) and (secret is None):
         raise Error("Set either the key_content or the key `secret`")
     if 'secret' in kwargs:
         utils.is_valid_base64(kwargs['secret'])
-    
     m = model.model(**kwargs)
     u = mdl_updater.model_updater(m)
     u.hostname_refresh()

--- a/_modules/sesceph/mdl_updater_remote.py
+++ b/_modules/sesceph/mdl_updater_remote.py
@@ -10,6 +10,7 @@ import shlex
 import keyring
 import constants
 import utils
+import mdl_query
 
 
 log = logging.getLogger(__name__)
@@ -155,6 +156,49 @@ class model_updater_remote():
         if prev_sec_name is not None:
             auth_list_out[prev_sec_name] = section
         self.model.auth_list = auth_list_out
+
+
+    def auth_add(self, keyring_type):
+        """
+        Authorise keyring
+        """
+        keyringobj = keyring.keyring_facard(self.model)
+        keyringobj.key_type = keyring_type
+
+
+        if not keyringobj.present():
+            raise Error("rgw keyring not found")
+        q = mdl_query.mdl_query(self.model)
+        if q.mon_is() and q.mon_quorum() is False:
+            raise Error("mon daemon is not in quorum")
+        arguments = [
+                "ceph",
+                "auth",
+                "import",
+                "-i",
+                keyringobj.keyring_path_get()
+                ]
+        cmd_out = utils.execute_local_command(arguments)
+        return True
+
+
+    def auth_del(self, **kwargs):
+        """
+        Remove Authorised keyring
+        """
+        keyringobj = keyring.keyring_facard(self.model)
+        keyringobj.key_type = keyring_type
+        q = mdl_query.mdl_query(self.model)
+        if q.mon_is() and q.mon_quorum() is False:
+            raise Error("mon daemon is not in quorum")
+        arguments = [
+                "ceph",
+                "auth",
+                "del",
+                keyringobj.keyring_path_get()
+                ]
+        cmd_out = utils.execute_local_command(arguments)
+        return True
 
 
     def pool_list(self):

--- a/_modules/sesceph/mdl_updater_remote.py
+++ b/_modules/sesceph/mdl_updater_remote.py
@@ -51,7 +51,7 @@ class model_updater_remote():
 
 
     def connect(self):
-        keyring_obj = keyring.keyring_facard()
+        keyring_obj = keyring.keyring_facard(self.model)
         for keytype in ["admin", "osd", "mds", "rgw", "mon"]:
             log.debug("Trying keyring:%s" % (keytype))
             keyring_obj.key_type = keytype

--- a/_modules/sesceph/model.py
+++ b/_modules/sesceph/model.py
@@ -47,4 +47,3 @@ class model:
     def kargs_apply(self, **kwargs):
         self.cluster_name = kwargs.get("cluster_name")
         self.cluster_uuid = kwargs.get("cluster_uuid")
-        self.secret = kwargs.get("secret", None)

--- a/_modules/sesceph/model.py
+++ b/_modules/sesceph/model.py
@@ -1,7 +1,7 @@
 import ConfigParser
 
 
-class version:
+class version(object):
     def __init__(self, **kwargs):
         self.major = kwargs.get("major")
         self.minor = kwargs.get("minor")
@@ -21,7 +21,7 @@ class version:
         return "<version(%s,%s,%s,%s)>" % (self.major, self.minor, self.revision, self.uuid)
 
 
-class model:
+class model(object):
     """
     Basic model class to store detrived data
     """

--- a/_modules/sesceph/purger.py
+++ b/_modules/sesceph/purger.py
@@ -185,13 +185,6 @@ def purge(mdl, **kwargs):
         salt '*' sesceph.purge
     """
     service_shutdown_ceph()
-    keyobj = keyring.keyring_facard(mdl)
-    for keytype in ["mds", "rgw", "osd", "mon", "admin"]:
-        try:
-            keyobj.key_type = keytype
-            keyobj.remove(**kwargs)
-        except:
-            pass
     pur_ctrl = purger(mdl)
     try:
         pur_ctrl.update_mon()
@@ -200,6 +193,13 @@ def purge(mdl, **kwargs):
     except utils.Error, e:
         log.error("exception self.updater.defaults_refresh()")
         log.error(e)
+    keyobj = keyring.keyring_facard(mdl)
+    for keytype in ["mds", "rgw", "osd", "mon", "admin"]:
+        try:
+            keyobj.key_type = keytype
+            keyobj.remove(**kwargs)
+        except:
+            pass
     try:
         pur_ctrl.update_osd()
         pur_ctrl.unmount_osd()

--- a/_modules/sesceph/purger.py
+++ b/_modules/sesceph/purger.py
@@ -5,7 +5,6 @@ import os.path
 # local modules
 import constants
 import utils
-import model
 import mdl_updater
 import service
 import keyring
@@ -41,8 +40,8 @@ def service_shutdown_ceph():
 
 
 class purger(object):
-    def __init__(self, **kwargs):
-        self.model = model.model(**kwargs)
+    def __init__(self, mdl):
+        self.model = mdl
         self.model.init = "systemd"
 
     def update_mon(self):
@@ -177,7 +176,7 @@ class purger(object):
             self.remove_dir(dir_data)
 
 
-def purge(**kwargs):
+def purge(mdl, **kwargs):
     """
     purge ceph configuration on the node
 
@@ -186,14 +185,14 @@ def purge(**kwargs):
         salt '*' sesceph.purge
     """
     service_shutdown_ceph()
-    keyobj = keyring.keyring_facard()
+    keyobj = keyring.keyring_facard(mdl)
     for keytype in ["mds", "rgw", "osd", "mon", "admin"]:
         try:
             keyobj.key_type = keytype
             keyobj.remove(**kwargs)
         except:
             pass
-    pur_ctrl = purger(**kwargs)
+    pur_ctrl = purger(mdl)
     try:
         pur_ctrl.update_mon()
     except mdl_updater.Error, e:

--- a/_modules/sesceph/purger.py
+++ b/_modules/sesceph/purger.py
@@ -197,9 +197,15 @@ def purge(mdl, **kwargs):
     for keytype in ["mds", "rgw", "osd", "mon", "admin"]:
         try:
             keyobj.key_type = keytype
-            keyobj.remove(**kwargs)
-        except:
-            pass
+
+        except keyring.error, E:
+            log.warning(E)
+            continue
+        if keyobj.present() is False:
+            log.info("Already removed '%s' keyring" % (keytype))
+            continue
+        log.info("Removing '%s' keyring" % (keytype))
+        keyobj.remove()
     try:
         pur_ctrl.update_osd()
         pur_ctrl.unmount_osd()


### PR DESCRIPTION
Add the following public methods.
    keyring_create
    keyring_save
    keyring_purge
    keyring_present
    keyring_auth_add
    keyring_auth_del

These will replace the type specific methods.

The related re factoring is for better use of the MVC design pattern.

The MVC design pattern can be composed of multiple MVC patterns if the controller
can be treated as a view. To allow this to happen the controller must not create
the model.
