### PR TITLE
Wip documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,31 +49,61 @@ Example
 
 Get a list of potential MON keys:
 
-    # salt "*ceph-node*" sesceph.keyring_admin_create
+    # salt "*ceph-node*" sesceph.keyring_create \
+        keyring_type=admin
 
 This will not persist the created key, but if a persistent key already exists 
 this function will return the persistent key.
 
-Use one output to write the keyring to admin nodes:
+Use the output to write the keyring to admin nodes:
 
-    # salt "*ceph-node*" sesceph.keyring_admin_save '[client.admin]
-    > key = AQDHYqZWkGHiEhAA5T+214L5CiIeek5o3zGZtQ==
-    > auid = 0
-    > caps mds = "allow *"
-    > caps mon = "allow *"
-    > caps osd = "allow *"
-    > '
+    # salt "*ceph-node*" sesceph.keyring_save \
+        keyring_type=admin \
+        secret='AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=='
 
 Repeat the process for the MON keyring:
 
-    # salt "*ceph-node*" sesceph.keyring_mon_create
+    # salt "*ceph-node*" sesceph.keyring_create \
+        keyring_type=mon
 
-Use one output to write the keyring to MON nodes:
+Use the output to write the keyring to MON nodes:
 
-    # salt "*ceph-node*" sesceph.keyring_mon_save '[mon.]
-    > key = AQCpY6ZW2KCRExAAxbJ+dljnln40wYmb7UvHcQ==
-    > caps mon = "allow *"
-    > '
+    # salt "*ceph-node*" sesceph.keyring_save \
+        keyring_type=admin \
+        secret='AQCpY6ZW2KCRExAAxbJ+dljnln40wYmb7UvHcQ=='
+
+Repeat the process for the osd keyring:
+
+    # salt "*ceph-node*" sesceph.keyring_create \
+        keyring_type=osd
+
+Use the output to write the keyring to osd and mon nodes:
+
+    # salt "*ceph-node*" sesceph.keyring_save \
+        keyring_type=osd \
+        secret='AQDant1WGP7qJBAA1Iqr9YoNo4YExai4ieXYMg=='
+
+Repeat the process for the rgw keyring:
+
+    # salt "*ceph-node*" sesceph.keyring_create \
+        keyring_type=rgw
+
+Use the output to write the keyring to rgw and mon nodes:
+
+    # salt "*ceph-node*" sesceph.keyring_save \
+        keyring_type=rgw \
+        secret='AQDant1WGP7qJBAA1Iqr9YoNo4YExai4ieXYMg=='
+
+Repeat the process for the mds keyring:
+
+    # salt "*ceph-node*" sesceph.keyring_create \
+        keyring_type=mds
+
+Use the output to write the keyring to mds and mon nodes:
+
+    # salt "*ceph-node*" sesceph.keyring_save \
+        keyring_type=mds \
+        secret='AQADn91WzLT9OBAA+LqKkXFBzwszBX4QkCkFYw=='
 
 Create the monitor daemons:
 

--- a/examples/cluster_buildup.sls
+++ b/examples/cluster_buildup.sls
@@ -18,53 +18,73 @@
 # First we need to create the keys.
 #
 # Note:
-# - This only needs to be done once per site.
+# - This only needs to be done once per cluster.
+
 
 keyring_admin_create:
   module.run:
-    - name: sesceph.keyring_admin_create
+    - name: sesceph.keyring_create
+    - kwargs: {
+        'keyring_type' : 'admin'
+        }
     - require:
       - file: /etc/ceph/ceph.conf
 
 
 keyring_mon_create:
   module.run:
-    - name: sesceph.keyring_mon_create
+    - name: sesceph.keyring_create
+    - kwargs: {
+        'keyring_type' : 'mon'
+        }
     - require:
       - file: /etc/ceph/ceph.conf
 
 
 keyring_osd_create:
   module.run:
-    - name: sesceph.keyring_osd_create
+    - name: sesceph.keyring_create
+    - kwargs: {
+        'keyring_type' : 'osd'
+        }
     - require:
       - file: /etc/ceph/ceph.conf
 
 
 keyring_rgw_create:
   module.run:
-    - name: sesceph.keyring_rgw_create
+    - name: sesceph.keyring_create
+    - kwargs: {
+        'keyring_type' : 'rgw'
+        }
     - require:
       - file: /etc/ceph/ceph.conf
 
 
 keyring_mds_create:
   module.run:
-    - name: sesceph.keyring_mds_create
+    - name: sesceph.keyring_create
+    - kwargs: {
+        'keyring_type' : 'mds'
+        }
     - require:
       - file: /etc/ceph/ceph.conf
+
 
 # Save the keys to the nodes so ceph can use them.
 #
 # Note:
 # - You should customise the 'secret' values for your site using the values from
 #   the previous create step
+# - All keys must be saved before the mon is created as this has a side effect
+#   of creating keys not managed by salt.
 
 keyring_admin_save:
   module.run:
-    - name: sesceph.keyring_admin_save
+    - name: sesceph.keyring_save
     - kwargs: {
-       'secret' : 'AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=='
+        'keyring_type' : 'admin',
+        'secret' : 'AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=='
         }
     - require:
       - module: keyring_admin_create
@@ -72,9 +92,10 @@ keyring_admin_save:
 
 keyring_mon_save:
   module.run:
-    - name: sesceph.keyring_mon_save
+    - name: sesceph.keyring_save
     - kwargs: {
-       'secret' : 'AQB/8KhWmIfENBAABq8EEbzCJMjEFoazMNb+oQ=='
+        'keyring_type' : 'mon',
+        'secret' : 'AQB/8KhWmIfENBAABq8EEbzCJMjEFoazMNb+oQ=='
         }
     - require:
       - module: keyring_mon_create
@@ -82,25 +103,28 @@ keyring_mon_save:
 
 keyring_osd_save:
   module.run:
-    - name: sesceph.keyring_osd_save
+    - name: sesceph.keyring_save
     - kwargs: {
-       'secret' : 'AQCxU6dWKJzuEBAAjh0WSiThjl+Ruvj3QCsDDQ=='
+        'keyring_type' : 'osd',
+        'secret' : 'AQCxU6dWKJzuEBAAjh0WSiThjl+Ruvj3QCsDDQ=='
         }
     - require:
       - module: keyring_osd_create
 
 keyring_rgw_save:
   module.run:
-    - name: sesceph.keyring_rgw_save
+    - name: sesceph.keyring_save
     - kwargs: {
-       'secret' : 'AQDant1WGP7qJBAA1Iqr9YoNo4YExai4ieXYMg=='
+        'keyring_type' : 'rgw',
+        'secret' : 'AQDant1WGP7qJBAA1Iqr9YoNo4YExai4ieXYMg=='
         }
 
 keyring_mds_save:
   module.run:
-    - name: sesceph.keyring_mds_save
+    - name: sesceph.keyring_save
     - kwargs: {
-       'secret' : 'AQADn91WzLT9OBAA+LqKkXFBzwszBX4QkCkFYw=='
+        'keyring_type' : 'mds',
+        'secret' : 'AQADn91WzLT9OBAA+LqKkXFBzwszBX4QkCkFYw=='
         }
 
 # Create the mon server
@@ -108,6 +132,8 @@ keyring_mds_save:
 # Note:
 # - This will throw and exception on non mon nodes.
 # - This is depenent on having 'saved' the mon and admin keys.
+# - Not saving the mds key on all mon nodes has a side effect
+#   of creating keys not managed by salt.
 
 mon_create:
     module.run:


### PR DESCRIPTION
README.md: keyrings create and save update

Use the sesceph.keyring_create and sesceph.keyring_save methods.

We should also use the "secret" parameter rather than transfer full keyrings.
