### PR TITLE
Wip cephx bootstrap

### DIFF
--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -259,12 +259,7 @@ class keyring_implementation_mds(keyring_implementation_base):
         return _get_path_keyring_mds(self.model.cluster_name)
 
     def get_arguments_create(self, path, secret=None):
-        # TODO ideally remove extra_args when we understand permisons better.
-        extra_args=[
-            "--cap", "osd", "allow *",
-            "--cap", "mon", "allow *"
-            ]
-        return self.invoke_ceph_authtool(self.keyring_name, path, self.caps, extra_args=extra_args, secret=secret)
+        return self.invoke_ceph_authtool(self.keyring_name, path, self.caps, secret=secret)
 
 
 class keyring_facard(object):

--- a/_modules/sesceph/keyring.py
+++ b/_modules/sesceph/keyring.py
@@ -244,15 +244,7 @@ class keyring_implementation_rgw(keyring_implementation_base):
 
 
     def get_arguments_create(self, path, secret=None):
-        # TODO ideally remove extra_args when we understand permisons better.
-        extra_args=["--cap",
-            "osd",
-            "allow *",
-            "--cap",
-            "mon",
-            "allow *"
-            ]
-        return self.invoke_ceph_authtool(self.keyring_name, path, self.caps, extra_args=extra_args, secret=secret)
+        return self.invoke_ceph_authtool(self.keyring_name, path, self.caps, secret=secret)
 
 
 class keyring_implementation_mds(keyring_implementation_base):

--- a/_modules/sesceph/mds.py
+++ b/_modules/sesceph/mds.py
@@ -88,9 +88,10 @@ class mds_ctrl(rados_client.ctrl_rados_client):
                 '--cluster', self.model.cluster_name,
                 '--name', 'client.bootstrap-mds',
                 '--keyring', path_bootstrap_keyring,
-                'auth', 'get-or-create', 'client.{name}'.format(name=self.mds_name),
+                'auth', 'get-or-create', 'mds.{name}'.format(name=self.mds_name),
                 'osd', 'allow rwx',
-                'mon', 'allow rw',
+                'mds', 'allow',
+                'mon', 'allow profile mds',
                 '-o',
                 mds_path_keyring
             ]

--- a/_modules/sesceph/rgw.py
+++ b/_modules/sesceph/rgw.py
@@ -86,6 +86,13 @@ class rgw_ctrl(rados_client.ctrl_rados_client):
 
 
     def prepare(self):
+        # Due to the way keyring profiles work and the init scripts for rgw we need to
+        # force users to only create rgw with a 'rgw.' prefix. The reason we dont hide
+        # this from the user is due to both the systemd files and rgw deployments may
+        # exist without the prefix if the bootstrap keyring was not used in the key
+        # creation for the rgw service.
+        if not self.rgw_name.startswith("rgw."):
+            raise Error("rgw name must start with 'rgw.'")
         missing_pools = self.rgw_pools_missing()
         if len(missing_pools) > 0:
             raise Error("Pools missing: %s" % (", ".join(missing_pools)))

--- a/examples/cluster_buildup.sls
+++ b/examples/cluster_buildup.sls
@@ -231,7 +231,7 @@ rgw_create:
   module.run:
     - name: sesceph.rgw_create
     - kwargs: {
-        name: rgw-{{ grains['machine_id'] }}
+        name: rgw.{{ grains['machine_id'] }}
         }
     - require:
       - module: rgw_prep
@@ -242,7 +242,7 @@ mds_create:
   module.run:
     - name: sesceph.mds_create
     - kwargs: {
-        name: mds-{{ grains['machine_id'] }},
+        name: mds.{{ grains['machine_id'] }},
         port: 1000,
         addr:{{ grains['fqdn_ip4'] }}
         }


### PR DESCRIPTION
Keyring rgw can make use of bootstrap-rgw
Keyring mds can make use of bootstrap-mds

These are more locked down than the previous keyring capabilities.
