### PR TITLE
_modules.sesceph.utils: improve logging of commands with spaces

### DIFF
--- a/_modules/sesceph/utils.py
+++ b/_modules/sesceph/utils.py
@@ -24,8 +24,15 @@ class Error(Exception):
         doc = self.__doc__.strip()
         return ': '.join([doc] + [str(a) for a in self.args])
 
+
+def _quote_arguments_with_space(argument):
+    if " " in argument:
+        return "'" + argument + "'"
+    return argument
+
+
 def execute_local_command(command_attrib_list):
-    log.info("executing " + " ".join(command_attrib_list))
+    log.info("executing " + " ".join(map(_quote_arguments_with_space, command_attrib_list)))
     if '__salt__' in locals():
         return __salt__['cmd.run_all'](command_attrib_list,
                                       python_shell=False)


### PR DESCRIPTION
Many ceph commands contain spaces in the arguments.

These commands now log with single quotes allowing copy and paste from
the logs without trying to guess where the argument starts and finishes.

A typical example is the commands :

```
/usr/bin/ceph-authtool -n client.admin \
--create-keyring /etc/ceph/ceph.client.admin.keyring \
--add-key AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w== \
--cap mds 'allow *' \
--cap mon 'allow *' \
--cap osd 'allow *'
```
