### PR TITLE
modules.ceph.init: Work around salt import bug

### DIFF
--- a/_modules/ceph_cfg/__init__.py
+++ b/_modules/ceph_cfg/__init__.py
@@ -7,6 +7,12 @@ __virtualname__ = 'ceph_cfg'
 
 try:
     import ceph_cfg
+    # Due to a bug in salt
+    # https://github.com/saltstack/salt/issues/35444
+    # we cant rely on previous import to
+    # detect that the library ceph_cfg is present.
+    # Hence we import the version of the library.
+    from ceph_cfg.__version__ import version as ceph_cfg_version
     HAS_CEPH_CFG = True
 except ImportError:
     HAS_CEPH_CFG = False


### PR DESCRIPTION
It seems salt adds external modules to the python path rather than as a
subdirectory or mangling the modules name. This can cause issues as stated in
bug report https://github.com/saltstack/salt/issues/35444

To work around this we import the **version** of the library as this is only
present in the library and not in the salt module.

Signed-off-by: Owen Synge osynge@suse.com
