### PR TITLE
modules.ceph_cfg.init

### DIFF
--- a/_modules/ceph_cfg/__init__.py
+++ b/_modules/ceph_cfg/__init__.py
@@ -947,7 +947,7 @@ def mon_status(**kwargs):
     cluster_name
         Set the cluster name. Defaults to "ceph".
     '''
-    return ceph_cfg.status(**kwargs)
+    return ceph_cfg.mon_status(**kwargs)
 
 
 def mon_quorum(**kwargs):


### PR DESCRIPTION
Fixed mon_status calling non existing function.

Signed-off-by: Owen Synge osynge@suse.com
