### PR TITLE
examples: add example salt states to deploy ceph

### DIFF
--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,0 +1,19 @@
+A simple example salt state files to use with
+
+https://github.com/oms4suse/python-ceph-cfg
+
+You should have a working salt setup for this.
+
+Copy the files from this repo into your respective salt and pillar directories
+(default is /srv/{salt,pillar}).
+Edit the configuration data in the pillar files in the pillar directory. For now edit
+the various secret keys and which device should become be used on osd nodes.
+Then run salt '*' state.apply.
+This will install ceph and python-ceph-cfg on all your nodes and start mon's,
+osd's and mds' on all nodes that have osd, mon or mds in their salt minion names.
+
+E.g. 3 node names mon-osd-node0, mon-osd-node1 and mon-osd-mds-node2 will give
+you a cluster with three mon's, three osd's and one mds.
+
+Missing Features to be added soon:
+* teardown states

--- a/examples/pillar/admin.sls
+++ b/examples/pillar/admin.sls
@@ -1,0 +1,2 @@
+admin:
+  secret: 'AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=_'

--- a/examples/pillar/mds.sls
+++ b/examples/pillar/mds.sls
@@ -1,0 +1,2 @@
+mds:
+  secret: 'AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=+'

--- a/examples/pillar/mon.sls
+++ b/examples/pillar/mon.sls
@@ -1,0 +1,2 @@
+mon:
+  secret: 'AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=-'

--- a/examples/pillar/osd.sls
+++ b/examples/pillar/osd.sls
@@ -1,0 +1,3 @@
+osd:
+  dev: /dev/vdb
+  secret: 'AQBR8KhWgKw6FhAAoXvTT6MdBE+bV+zPKzIo6w=='

--- a/examples/pillar/top.sls
+++ b/examples/pillar/top.sls
@@ -1,0 +1,8 @@
+base:
+    "*osd*":
+        - osd
+    "*mds*":
+        - mds
+    "*mon*":
+        - mon
+        - admin

--- a/examples/salt/ses/ceph/ceph.conf
+++ b/examples/salt/ses/ceph/ceph.conf
@@ -1,0 +1,8 @@
+[global]
+fsid = eaac9695-4265-4ca8-ac2a-f3a479c559b1
+mon_initial_members = osd-mon-node0, mon-osd-mds-node1, mon-osd-node2
+mon_host = 192.168.100.168,192.168.100.223,192.168.100.130
+auth_cluster_required = cephx
+auth_service_required = cephx
+auth_client_required = cephx
+filestore_xattr_use_omap = true

--- a/examples/salt/ses/ceph/init.sls
+++ b/examples/salt/ses/ceph/init.sls
@@ -1,0 +1,17 @@
+packages:
+  pkg.installed:
+    - names:
+      - ceph
+      - python-ceph-cfg
+
+/etc/ceph/ceph.conf:
+  file:
+    - managed
+    - source:
+      - salt://ses/ceph/ceph.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - require:
+      - pkg: packages

--- a/examples/salt/ses/common/admin_key.sls
+++ b/examples/salt/ses/common/admin_key.sls
@@ -1,0 +1,9 @@
+keyring_admin_save:
+  module.run:
+    - name: ceph.keyring_save
+    - kwargs: {
+        'keyring_type' : 'admin',
+        'secret' : {{ salt['pillar.get']('admin.secret', 'AQBR8KhWgKw6FhAA__DEFAULT_KEY__PKzIo6def') }}
+        }
+    - require:
+      - sls: ses.ceph

--- a/examples/salt/ses/common/mds_key.sls
+++ b/examples/salt/ses/common/mds_key.sls
@@ -1,0 +1,9 @@
+keyring_mds_save:
+  module.run:
+    - name: ceph.keyring_save
+    - kwargs: {
+        'keyring_type' : 'mds',
+        'secret' : {{ salt['pillar.get']('mds.secret', 'AQBR8KhWgKw6FhAA__DEFAULT_KEY__PKzIo6def') }}
+        }
+    - require:
+      - sls: ses.ceph

--- a/examples/salt/ses/common/mon_key.sls
+++ b/examples/salt/ses/common/mon_key.sls
@@ -1,0 +1,9 @@
+keyring_mon_save:
+  module.run:
+    - name: ceph.keyring_save
+    - kwargs: {
+        'keyring_type' : 'mon',
+        'secret' : {{ salt['pillar.get']('mds.secret', 'AQBR8KhWgKw6FhAA__DEFAULT_KEY__PKzIo6def') }}
+        }
+    - require:
+      - sls: ses.ceph

--- a/examples/salt/ses/common/osd_key.sls
+++ b/examples/salt/ses/common/osd_key.sls
@@ -1,0 +1,9 @@
+keyring_osd_save:
+  module.run:
+    - name: ceph.keyring_save
+    - kwargs: {
+        'keyring_type' : 'osd',
+        'secret' : {{ salt['pillar.get']('osd.secret', 'AQBR8KhWgKw6FhAA__DEFAULT_KEY__PKzIo6def') }}
+        }
+    - require:
+      - sls: ses.ceph

--- a/examples/salt/ses/common/rgw_key.sls
+++ b/examples/salt/ses/common/rgw_key.sls
@@ -1,0 +1,9 @@
+keyring_rgw_save:
+  module.run:
+    - name: ceph.keyring_save
+    - kwargs: {
+        'keyring_type' : 'rgw',
+        'secret' : {{ salt['pillar.get']('rgw.secret', 'AQBR8KhWgKw6FhAA__DEFAULT_KEY__PKzIo6def') }}
+        }
+    - require:
+      - sls: ses.ceph

--- a/examples/salt/ses/mds/init.sls
+++ b/examples/salt/ses/mds/init.sls
@@ -1,0 +1,22 @@
+include:
+  - ses.ceph
+  - ses.common.mds_key
+
+keyring_mds_auth_add:
+  module.run:
+    - name: ceph.keyring_mds_auth_add
+    - require:
+      - module: keyring_mds_save
+      - ceph: cluster_status
+
+mds_create:
+  module.run:
+    - name: ceph.mds_create
+    - kwargs: {
+        name: mds.{{ grains['machine_id'] }},
+        port: 1000,
+        addr:{{ grains['fqdn_ip4'] }}
+        }
+    - require:
+      - module: keyring_mds_auth_add
+

--- a/examples/salt/ses/mon/init.sls
+++ b/examples/salt/ses/mon/init.sls
@@ -1,0 +1,17 @@
+include:
+  - ses.ceph
+  - ses.common.admin_key
+  - ses.common.mon_key
+
+mon_create:
+    module.run:
+    - name: ceph.mon_create
+    - require:
+      - module: keyring_admin_save
+      - module: keyring_mon_save
+
+cluster_status:
+    ceph.quorum:
+    - require:
+      - module: mon_create
+

--- a/examples/salt/ses/osd/init.sls
+++ b/examples/salt/ses/osd/init.sls
@@ -1,0 +1,30 @@
+include:
+  - ses.ceph
+  - ses.common.osd_key
+
+keyring_osd_auth_add:
+  module.run:
+    - name: ceph.keyring_osd_auth_add
+    - require:
+      - module: keyring_osd_save
+      - ceph: cluster_status
+
+# Prepare disks for OSD use
+
+prepare_vdb:
+  module.run:
+    - name: ceph.osd_prepare
+    - kwargs: {
+        osd_dev: /dev/vdb
+        }
+    - require:
+      - module: keyring_osd_auth_add
+
+# Activate OSD's on prepared disks
+
+activate_vdb:
+  module.run:
+    - name: ceph.osd_activate
+    - kwargs: {
+        osd_dev: /dev/vdb
+        }

--- a/examples/salt/ses/rgw/init.sls
+++ b/examples/salt/ses/rgw/init.sls
@@ -1,0 +1,3 @@
+include:
+  - ses.ceph
+  - ses.common.rgw_key

--- a/examples/salt/top.sls
+++ b/examples/salt/top.sls
@@ -1,0 +1,9 @@
+base:
+  '*':
+    - ses.ceph
+  '*mon*':
+    - ses.mon
+  '*osd*':
+    - ses.osd
+  '*mds*':
+    - ses.mds


### PR DESCRIPTION
The examples should illustrate how to use python-ceph-cfg to deploy a
basic ceph cluster. Could be improved with a pillar file to hold some
config data.

Signed-off-by: Jan Fajerski jfajerski@suse.com
