### PR TITLE
Wip fix example

### DIFF
--- a/examples/basic/cluster_buildup.sls
+++ b/examples/basic/cluster_buildup.sls
@@ -165,6 +165,9 @@ keyring_mds_save:
 mon_create:
     module.run:
     - name: ceph_cfg.mon_create
+    - kwargs: {
+        mon_name: {{ grains['localhost'] }}
+        }
     - require:
       - module: keyring_admin_save
       - module: keyring_mon_save

--- a/examples/using_pillar/salt/ses/mon/init.sls
+++ b/examples/using_pillar/salt/ses/mon/init.sls
@@ -6,6 +6,9 @@ include:
 mon_create:
     module.run:
     - name: ceph.mon_create
+    - kwargs: {
+        mon_name: {{ grains['localhost'] }}
+        }
     - require:
       - module: keyring_admin_save
       - module: keyring_mon_save


### PR DESCRIPTION
Add mon_name

Latest version of python-ceph-cfg requires a mon_name as a parameter for 
mon_create.

Signed-off-by: Owen Synge osynge@suse.com
