### PR TITLE
modules.ceph_cfg.init: Improve documentation for mon methods.

### DIFF
--- a/_modules/ceph_cfg/__init__.py
+++ b/_modules/ceph_cfg/__init__.py
@@ -946,9 +946,13 @@ def mon_is(**kwargs):
     .. code-block:: bash
 
         salt '*' ceph_cfg.mon_is \\
+                'mon_name'='mon_01' \\
                 'cluster_name'='ceph' \\
                 'cluster_uuid'='cluster_uuid'
     Notes:
+
+    mon_name
+        Set the mon service name. Required
 
     cluster_name
         Set the cluster name. Defaults to "ceph".
@@ -961,16 +965,20 @@ def mon_is(**kwargs):
 
 def mon_status(**kwargs):
     '''
-    Get status from mon deamon
+    Get status from local mon deamon
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' ceph_cfg.mon_status \\
+                'mon_name'='mon_01' \\
                 'cluster_name'='ceph' \\
                 'cluster_uuid'='cluster_uuid'
     Notes:
+
+    mon_name
+        Set the mon service name. Required
 
     cluster_uuid
         Set the cluster UUID. Defaults to value found in ceph config file.
@@ -983,16 +991,20 @@ def mon_status(**kwargs):
 
 def mon_quorum(**kwargs):
     '''
-    Is mon deamon in quorum
+    Is local mon deamon in quorum
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' ceph_cfg.mon_quorum \\
+                'mon_name'='mon_01' \\
                 'cluster_name'='ceph' \\
                 'cluster_uuid'='cluster_uuid'
     Notes:
+
+    mon_name
+        Set the mon service name. Required
 
     cluster_uuid
         Set the cluster UUID. Defaults to value found in ceph config file.
@@ -1012,9 +1024,13 @@ def mon_active(**kwargs):
     .. code-block:: bash
 
         salt '*' ceph_cfg.mon_active \\
+                'mon_name'='mon_01' \\
                 'cluster_name'='ceph' \\
                 'cluster_uuid'='cluster_uuid'
     Notes:
+
+    mon_name
+        Set the mon serrvice name. Required
 
     cluster_uuid
         Set the cluster UUID. Defaults to value found in ceph config file.
@@ -1027,7 +1043,7 @@ def mon_active(**kwargs):
 
 def mon_create(**kwargs):
     '''
-    Create a mon node
+    Create a mon service on local node
 
     CLI Example:
 
@@ -1053,7 +1069,7 @@ def mon_create(**kwargs):
 
 def mon_destroy(**kwargs):
     '''
-    Destroy a mon node
+    Destroy a mon service
 
     CLI Example:
 
@@ -1079,7 +1095,7 @@ def mon_destroy(**kwargs):
 
 def mon_list(**kwargs):
     '''
-    Create a mon node
+    List mon services on local node
 
     CLI Example:
 

--- a/_modules/ceph_cfg/__init__.py
+++ b/_modules/ceph_cfg/__init__.py
@@ -965,7 +965,7 @@ def mon_is(**kwargs):
 
 def mon_status(**kwargs):
     '''
-    Get status from local mon deamon
+    Get status from mon deamon
 
     CLI Example:
 
@@ -991,7 +991,7 @@ def mon_status(**kwargs):
 
 def mon_quorum(**kwargs):
     '''
-    Is local mon deamon in quorum
+    Is mon deamon in quorum
 
     CLI Example:
 
@@ -1043,7 +1043,7 @@ def mon_active(**kwargs):
 
 def mon_create(**kwargs):
     '''
-    Create a mon service on local node
+    Create a mon service on node
 
     CLI Example:
 
@@ -1095,7 +1095,7 @@ def mon_destroy(**kwargs):
 
 def mon_list(**kwargs):
     '''
-    List mon services on local node
+    List mon services on node
 
     CLI Example:
 


### PR DESCRIPTION
Documentation for mon methods did not include mon_name paramter.

Signed-off-by: Owen Synge osynge@suse.com
